### PR TITLE
feat: Add summary overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 __pycache__/
 dist/
 ohme.egg-info/
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 dist/
 ohme.egg-info/
+.env

--- a/ohme/const.py
+++ b/ohme/const.py
@@ -1,4 +1,4 @@
 """Constants for Ohme API library."""
 
 GOOGLE_API_KEY = "AIzaSyC8ZeZngm33tpOXLpbXeKfwtyZ1WrkbdBY"
-VERSION = "1.6.0"
+VERSION = "1.8.0"

--- a/ohme/ohme.py
+++ b/ohme/ohme.py
@@ -1,5 +1,4 @@
 """Ohme API library."""
-from __future__ import annotations
 
 import logging
 import asyncio
@@ -7,7 +6,7 @@ import json
 import base64
 from time import time
 from enum import Enum
-from typing import Any, List, Mapping, Optional, TypedDict
+from typing import Any, List, Mapping, Optional, Self, TypedDict
 from dataclasses import dataclass
 import datetime
 import aiohttp
@@ -42,9 +41,11 @@ class SummaryGranularity(Enum):
     DAY = "DAY"
     HOUR = "HOUR"
 
+
 class Money(TypedDict):
     currencyCode: str
     amount: str
+
 
 class ChargeStat(TypedDict):
     ownerUserId: str
@@ -92,10 +93,12 @@ class ChargeStat(TypedDict):
         },
     )
 
+
 class ChargeSummary(TypedDict):
     totalStats: ChargeStat
     stats: List[ChargeStat]
     granularity: SummaryGranularity
+
 
 @dataclass
 class ChargerPower:
@@ -240,8 +243,9 @@ class OhmeApiClient:
             async with self._session.request(
                 method=method,
                 url=f"https://api.ohme.io{url}",
-                data=json.dumps(data) if data and method in {
-                    "PUT", "POST", "PATCH"} else data,
+                data=json.dumps(data)
+                if data and method in {"PUT", "POST", "PATCH"}
+                else data,
                 headers={
                     "Authorization": f"Firebase {self._token}",
                     "Content-Type": "application/json",
@@ -260,7 +264,7 @@ class OhmeApiClient:
 
     @staticmethod
     def _extract_user_id(token: str | None) -> str | None:
-        """Extract user_id from a JWT-style API token payload."""
+        """Extract user_id from a JWT token payload."""
         if not token:
             return None
         try:
@@ -446,8 +450,8 @@ class OhmeApiClient:
         """Enable max charge"""
         result = await self._make_request(
             "PUT",
-            f"/v2/charge-devices/{self.serial}/charge-sessions/active/{self.serial}/max-charge?enabled=" + str(
-                state).lower(),
+            f"/v2/charge-devices/{self.serial}/charge-sessions/active/{self.serial}/max-charge?enabled="
+            + str(state).lower(),
         )
         return bool(result)
 
@@ -495,8 +499,7 @@ class OhmeApiClient:
         if target_percent is not None:
             rule["targetPercent"] = target_percent
         if target_time is not None:
-            rule["targetTime"] = (target_time[0] * 3600) + \
-                (target_time[1] * 60)
+            rule["targetTime"] = (target_time[0] * 3600) + (target_time[1] * 60)
 
         # Update pre-conditioning if provided
         if pre_condition is not None:
@@ -520,8 +523,7 @@ class OhmeApiClient:
             data["targetPercent"] = target_percent
 
         if target_time is not None:
-            data["targetTime"] = (target_time[0] * 3600) + \
-                (target_time[1] * 60)
+            data["targetTime"] = (target_time[0] * 3600) + (target_time[1] * 60)
 
         if pre_condition_length is not None:
             data["preconditioning"] = {
@@ -530,9 +532,9 @@ class OhmeApiClient:
                 "temperature": None,
             }
 
-        session_id = self._last_rule.get('id')
+        session_id = self._last_rule.get("id")
         if session_id is None:
-            session_id = self._next_session.get('id')
+            session_id = self._next_session.get("id")
 
         await self._make_request(
             "PATCH",
@@ -611,14 +613,14 @@ class OhmeApiClient:
     ) -> ChargeSummary:
         """
         Fetch charge sessions summary.
-        
+
         :param start_ts: Unix timestamp in milliseconds for start of summary. Defaults to 24 hours ago.
         :param end_ts: Unix timestamp in milliseconds for end of summary. Defaults to now.
         :param granularity: Granularity of the summary data. Can be "DAY" or "HOUR".
         """
         if end_ts is None:
             end_ts = int(time() * 1000)
-            
+
         if start_ts is None:
             start_ts = end_ts - (24 * 60 * 60 * 1000)
 
@@ -674,7 +676,7 @@ class OhmeApiClient:
         if self._session and self._close_session:
             await self._session.close()
 
-    async def __aenter__(self) -> "OhmeApiClient":
+    async def __aenter__(self) -> Self:
         """Async enter."""
         return self
 

--- a/ohme/ohme.py
+++ b/ohme/ohme.py
@@ -7,7 +7,7 @@ import json
 import base64
 from time import time
 from enum import Enum
-from typing import Any, Optional, Mapping
+from typing import Any, List, Mapping, Optional, TypedDict
 from dataclasses import dataclass
 import datetime
 import aiohttp
@@ -35,6 +35,67 @@ class ChargerMode(Enum):
     MAX_CHARGE = "max_charge"
     PAUSED = "paused"
 
+
+class SummaryGranularity(Enum):
+    """Granularity for charge summary data."""
+
+    DAY = "DAY"
+    HOUR = "HOUR"
+
+class Money(TypedDict):
+    currencyCode: str
+    amount: str
+
+class ChargeStat(TypedDict):
+    ownerUserId: str
+    deviceId: Optional[str]
+    energyChargedTotalWh: int
+    solarEnergyChargedWh: int
+    startTime: int
+    endTime: int
+    activeChargeMs: int
+    location: Optional[str]
+    locationType: Optional[str]
+
+    carbonStats: TypedDict(
+        "CarbonStats",
+        {
+            "carbonReleasedGreenScore": float,
+            "carbonReleasedPerKmGrams": int,
+            "carbonReleasedGrams": int,
+            "carbonReleasedRegularCableGrams": int,
+            "carbonSavedVsRegularCableGrams": int,
+            "carbonReleasedGasCarGrams": int,
+            "carbonSavedVsGasCarGrams": int,
+            "comparedGasCarLabel": Optional[str],
+        },
+        total=False,
+    )
+
+    costStats: TypedDict(
+        "CostStats",
+        {
+            "moneyCostTotal": Money,
+            "moneyCostStandardTariff": Money,
+            "moneySavedVsStandardTariff": Money,
+            "moneyCostPerKm": Money,
+            "averageKwhPrice": Money,
+        },
+    )
+
+    batteryStats: TypedDict(
+        "BatteryStats",
+        {
+            "batteryScore": float,
+            "batteryCycleUsePercent": int,
+            "rangeAddedKm": float,
+        },
+    )
+
+class ChargeSummary(TypedDict):
+    totalStats: ChargeStat
+    stats: List[ChargeStat]
+    granularity: SummaryGranularity
 
 @dataclass
 class ChargerPower:
@@ -220,7 +281,7 @@ class OhmeApiClient:
 
     def is_capable(self, capability: str) -> bool:
         """Return whether or not this model has a given capability."""
-        return bool(self._capabilities[capability])
+        return bool(self._capabilities.get(capability))
 
     def configuration_value(self, value: str) -> bool:
         """Return a boolean configuration value."""
@@ -604,10 +665,10 @@ class OhmeApiClient:
         self,
         start_ts: Optional[int] = None,
         end_ts: Optional[int] = None,
-        granularity: str = "DAY",
-    ) -> dict[str, Any]:
+        granularity: SummaryGranularity = SummaryGranularity.DAY,
+    ) -> ChargeSummary:
         """
-        Fetch charge sessions summary endpoint.
+        Fetch charge sessions summary.
         
         :param start_ts: Unix timestamp in milliseconds for start of summary. Defaults to 24 hours ago.
         :param end_ts: Unix timestamp in milliseconds for end of summary. Defaults to now.
@@ -630,8 +691,10 @@ class OhmeApiClient:
         if not self._user_id:
             raise ApiException("Could not determine user ID from API token")
 
-        url = f"/v1/chargeSessions/summary/users/{self._user_id}?endTs={end_ts}&granularity={granularity}&startTs={start_ts}"
-        return await self._make_request("GET", url)
+        url = f"/v1/chargeSessions/summary/users/{self._user_id}?endTs={end_ts}&granularity={granularity.value}&startTs={start_ts}"
+        resp = await self._make_request("GET", url)
+        resp["granularity"] = SummaryGranularity(resp["granularity"])
+        return resp
 
     async def async_update_device_info(self) -> bool:
         """Update _device_info with our charger model."""

--- a/ohme/ohme.py
+++ b/ohme/ohme.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 import asyncio
-import async_timeout
 import json
 import base64
 from time import time
@@ -80,6 +79,7 @@ class OhmeApiClient:
         self._token_birth: float = 0.0
         self._token: str | None = None
         self._refresh_token: str | None = None
+        self._user_id: str | None = None
 
         # User info
         self.serial = ""
@@ -98,7 +98,7 @@ class OhmeApiClient:
             self._session = aiohttp.ClientSession()
             self._close_session = True
 
-        async with async_timeout.timeout(self._timeout):
+        async with asyncio.timeout(self._timeout):
             async with self._session.post(
                 f"https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyPassword?key={GOOGLE_API_KEY}",
                 data={
@@ -114,6 +114,7 @@ class OhmeApiClient:
                 self._token_birth = time()
                 self._token = resp_json["idToken"]
                 self._refresh_token = resp_json["refreshToken"]
+                self._user_id = self._extract_user_id(self._token)
                 return True
         raise AuthException("Incorrect credentials")
 
@@ -130,7 +131,7 @@ class OhmeApiClient:
             self._session = aiohttp.ClientSession()
             self._close_session = True
 
-        async with async_timeout.timeout(self._timeout):
+        async with asyncio.timeout(self._timeout):
             async with self._session.post(
                 f"https://securetoken.googleapis.com/v1/token?key={GOOGLE_API_KEY}",
                 data={
@@ -148,6 +149,7 @@ class OhmeApiClient:
                 self._token_birth = time()
                 self._token = resp_json["id_token"]
                 self._refresh_token = resp_json["refresh_token"]
+                self._user_id = self._extract_user_id(self._token)
                 return True
 
     # Internal methods
@@ -174,7 +176,7 @@ class OhmeApiClient:
             self._session = aiohttp.ClientSession()
             self._close_session = True
 
-        async with async_timeout.timeout(self._timeout):
+        async with asyncio.timeout(self._timeout):
             async with self._session.request(
                 method=method,
                 url=f"https://api.ohme.io{url}",
@@ -194,6 +196,18 @@ class OhmeApiClient:
                     return await resp.text()
 
                 return await resp.json() if method != "PUT" else True
+
+    @staticmethod
+    def _extract_user_id(token: str | None) -> str | None:
+        """Extract user_id from a JWT-style API token payload."""
+        if not token:
+            return None
+        try:
+            payload = token.split(".")[1]
+            payload += "=" * ((4 - len(payload) % 4) % 4)
+            return json.loads(base64.b64decode(payload)).get("user_id")
+        except Exception:
+            return None
 
     def _charge_in_progress(self) -> bool:
         """Is a charge in progress? Used to determine if schedule or session should be adjusted."""
@@ -607,18 +621,16 @@ class OhmeApiClient:
 
         if not self._token:
             await self._async_refresh_session()
-            
+
         if not self._token:
             raise AuthException("Not authenticated")
 
-        payload = self._token.split(".")[1]
-        payload += "=" * ((4 - len(payload) % 4) % 4)
-        user_id = json.loads(base64.b64decode(payload)).get("user_id")
-
-        if not user_id:
+        if not self._user_id:
+            self._user_id = self._extract_user_id(self._token)
+        if not self._user_id:
             raise ApiException("Could not determine user ID from API token")
 
-        url = f"/v1/chargeSessions/summary/users/{user_id}?endTs={end_ts}&granularity={granularity}&startTs={start_ts}"
+        url = f"/v1/chargeSessions/summary/users/{self._user_id}?endTs={end_ts}&granularity={granularity}&startTs={start_ts}"
         return await self._make_request("GET", url)
 
     async def async_update_device_info(self) -> bool:

--- a/ohme/utils.py
+++ b/ohme/utils.py
@@ -8,6 +8,7 @@ JsonValueType = Union[
     Dict[str, "JsonValueType"], List["JsonValueType"], str, int, float, bool, None
 ]
 
+
 @dataclass
 class ChargeSlot:
     """Dataclass for reporting an individual charge slot."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ohme"
-version = "1.6.0"
+version = "1.8.0"
 authors = [
   { name="Dan Raper", email="git@danr.uk" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 description = "A Python wrapper for the Ohme API, used by the Home Assistant integration."
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## Description
This PR introduces a new method [async_get_charge_summary](cci:1://file:///Users/williamsearle/projects/ohmepy/ohme/ohme.py:588:4-621:51) to the [OhmeApiClient](cci:2://file:///Users/williamsearle/projects/ohmepy/ohme/ohme.py:48:0-665:26) which interfaces with the `/v1/chargeSessions/summary/users/{user_id}` API endpoint.

This endpoint allows developers to fetch historical charge session summaries including details like total energy charged, cost, carbon released, and carbon saved. 

**Key Changes:**
- Added [async_get_charge_summary](cci:1://file:///Users/williamsearle/projects/ohmepy/ohme/ohme.py:588:4-621:51) alongside other pull methods in [ohme.py](cci:7://file:///Users/williamsearle/projects/ohmepy/ohme/ohme.py:0:0-0:0).
- Added extraction of the `user_id` from the existing Firebase JWT token (since passing `/users/me` throws a `403 Forbidden` response for this specific endpoint).
- Decoded the payload locally via `base64` to prevent any additional network overhead or reliance on external modules.
- Made `start_ts` and `end_ts` optional, defaulting to fetching the last 24 hours of data.
- Allowed configurability of the summary `granularity` which defaults to `"DAY"`.

## Testing
- Verified successful API extraction using dummy scripts printing total energy charged and green score.

## Example Usage
```python
summary = await client.async_get_charge_summary(
    start_ts=start_ts_ms,
    end_ts=end_ts_ms,
    granularity="DAY"
)

# Extract example stats:
energy_wh = summary.get('totalStats', {}).get('energyChargedTotalWh')
carbon_stats = summary.get('totalStats', {}).get('carbonStats', {})
green_score = carbon_stats.get('carbonReleasedGreenScore')
