### PR TITLE
Expose session timestamps and add week/month summary granularity

### DIFF
--- a/ohme/models.py
+++ b/ohme/models.py
@@ -31,6 +31,8 @@ class SummaryGranularity(Enum):
 
     DAY = "DAY"
     HOUR = "HOUR"
+    WEEK = "WEEK"
+    MONTH = "MONTH"
 
 
 class Money(TypedDict):

--- a/ohme/ohme.py
+++ b/ohme/ohme.py
@@ -10,7 +10,7 @@ from typing import Any, List, Mapping, Optional, Self, TypedDict
 from dataclasses import dataclass
 import datetime
 import aiohttp
-from .utils import ChargeSlot, slot_list, vehicle_to_name
+from .utils import ChargeSlot, parse_datetime, slot_list, vehicle_to_name
 from .const import VERSION, GOOGLE_API_KEY
 from .models import (
     ChargerStatus,
@@ -240,6 +240,16 @@ class OhmeApiClient:
     def max_charge(self) -> bool:
         """Get if max charge is enabled."""
         return self._charge_session.get("mode") == "MAX_CHARGE"
+
+    @property
+    def session_start(self) -> datetime.datetime | None:
+        """Return the active or completed session start time, if available."""
+        return parse_datetime(self._charge_session.get("startTime"))
+
+    @property
+    def session_finish(self) -> datetime.datetime | None:
+        """Return the completed session finish time, if available."""
+        return parse_datetime(self._charge_session.get("finishTime"))
 
     @property
     def power(self) -> ChargerPower:
@@ -546,7 +556,7 @@ class OhmeApiClient:
 
         :param start_ts: Unix timestamp in milliseconds for start of summary. Defaults to 24 hours ago.
         :param end_ts: Unix timestamp in milliseconds for end of summary. Defaults to now.
-        :param granularity: Granularity of the summary data. Can be "DAY" or "HOUR".
+        :param granularity: Granularity of the summary data. Can be DAY, HOUR, WEEK, or MONTH.
         """
         if end_ts is None:
             end_ts = int(time() * 1000)

--- a/ohme/utils.py
+++ b/ohme/utils.py
@@ -80,6 +80,36 @@ def slot_list(data: Dict[str, Any], collapse=True) -> List[ChargeSlot]:
     return merged_slots
 
 
+def parse_datetime(value: Any) -> datetime.datetime | None:
+    """Parse Ohme datetime values into aware UTC datetimes."""
+    if value is None:
+        return None
+
+    if isinstance(value, datetime.datetime):
+        return value.astimezone(datetime.timezone.utc)
+
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.datetime.fromtimestamp(
+                value / 1000, tz=datetime.timezone.utc
+            )
+        except (OverflowError, OSError, ValueError):
+            return None
+
+    if not isinstance(value, str):
+        return None
+
+    try:
+        parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+
+    return parsed.astimezone(datetime.timezone.utc)
+
+
 def vehicle_to_name(vehicle: Dict[str, Any]) -> str:
     """Translate vehicle object to human readable name."""
     if vehicle.get("name") is not None:


### PR DESCRIPTION
## Summary
- expose public `session_start` / `session_finish` accessors on `OhmeApiClient`
- add `WEEK` and `MONTH` to `SummaryGranularity`
- keep the summary API surface aligned with values supported by the underlying Ohme endpoint

## Why
The history-sync flow I'm working on uses session boundary timestamps. Those timestamps are already present in the charge-session payload, but without public accessors callers have to read private client internals.

`WEEK` and `MONTH` are also accepted by the Ohme summary endpoint, so exposing them in the enum makes the wrapper more complete and avoids ad hoc string handling.

## Validation
- exercised via the local Home Assistant Ohme integration
- `pytest -q tests/components/ohme`
- result: `44 passed`